### PR TITLE
have a better svg icon to display the latest tested version

### DIFF
--- a/sage_trac/templates/ticket_box.html
+++ b/sage_trac/templates/ticket_box.html
@@ -44,6 +44,7 @@ Arguments:
   <div class="date">
     <a href="http://patchbot.sagemath.org/ticket/${ticket.id}/">
     <img src="http://patchbot.sagemath.org/ticket/${ticket.id}/status.png?nonce=${nonce}" border="0" height="32"/>
+    <img src="http://patchbot.sagemath.org/ticket/${ticket.id}/base.svg?nonce=${nonce}" border="0" height="32"/>
     <img src="http://patchbot.sagemath.org/ticket/${ticket.id}/status.svg?nonce=${nonce}" border="0" height="32"/>
   </a>
   </div>


### PR DESCRIPTION
I have made a better icon (svg and easier to read) for the sage version ; let us first add it besides the png analog, and later remove the latter.
