### PR TITLE
Minor updates to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools import setup, find_packages
 setup(
         name='sage_trac',
         version='0.2',
+        url='https://github.com/sagemath/sage_trac_plugin',
         packages=find_packages(),
         zip_safe=True,
         package_data={

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from setuptools import setup, find_packages
 

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ setup(
                 'templates/prefs_ssh_keys.html',
                 ],
             },
+        install_requires=['pygit2', 'TracXMLRPC'],
+        dependency_links=['https://trac-hacks.org/svn/xmlrpcplugin/trunk#egg=TracXMLRPC'],
         entry_points={
             'trac.plugins': [
                 'sage_trac = sage_trac',


### PR DESCRIPTION
Set its mode as executable, which is always convenient.  Don't force it to use an executable named 'python2' in the shebang line--just "Python" should be fine.  If use of Python 2 must be enforced better to do it with a explicit `sys.version_info` check.
