### PR TITLE
Updated handling of SSH keys

### DIFF
--- a/sage_trac/sshkeys.py
+++ b/sage_trac/sshkeys.py
@@ -22,8 +22,9 @@ class UserDataStore(Component):
         self._create_table()
         with self.env.db_transaction as db:
             cursor = db.cursor()
+            cursor.execute('DELETE FROM "user_data_store" WHERE "user"=%s', (user,))
+
             for key, value in dictionary.iteritems():
-                cursor.execute('DELETE FROM "user_data_store" WHERE "user"=%s', (user,))
                 cursor.execute('INSERT INTO "user_data_store" VALUES (%s, %s, %s)', (user, key, value))
 
     def get_data(self, user):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
                 'templates/prefs_ssh_keys.html',
                 ],
             },
-        install_requires=['pygit2', 'TracXMLRPC'],
+        install_requires=['pygit2', 'TracXMLRPC', 'fasteners'],
         dependency_links=['https://trac-hacks.org/svn/xmlrpcplugin/trunk#egg=TracXMLRPC'],
         entry_points={
             'trac.plugins': [


### PR DESCRIPTION
Updated the SSH key handling module so that it's entirely responsible for cloning the gitolite-admin repository, and managing that clone entirely on its own.

This still requires that the webserver's user has an SSH key that is stored in the gitolite-admin repo, and is granted R/W access to gitolite-admin.  This has to be set up manually.  The rest is self-contained in the plugin.

Error handling could still be improved.  I found a _lot_ of invalid SSH keys in the gitolite-admin repo.  It would be good to check the validity of keys before saving them.
