### PR TITLE
Make config options more consistent

### DIFF
--- a/sage_trac/buildbot_hook.py
+++ b/sage_trac/buildbot_hook.py
@@ -6,7 +6,7 @@ from trac.ticket.model import Ticket
 from trac.web.api import ITemplateStreamFilter
 from tracrpc.api import IXMLRPCHandler
 
-from .common import *
+from .common import GitBase, hexify
 
 from . import git_merger
 
@@ -73,11 +73,11 @@ class BuildbotHook(git_merger.GitMerger):
                 base, builder, number, status = cursor.next()
             except StopIteration:
                 if self.master.hex != commit:
-                    self._real_get_build(MASTER_BRANCH)
+                    self._real_get_build(self.master_branch)
                 return None
         if base != self.master.hex:
             BuildbotHook._drop_table(self)
-            self._real_get_build(MASTER_BRANCH)
+            self._real_get_build(self.master_branch)
             return None
         return builder, number, status
 

--- a/sage_trac/buildbot_hook.py
+++ b/sage_trac/buildbot_hook.py
@@ -143,7 +143,9 @@ class BuildbotHook(git_merger.GitMerger):
                 }
 
         if tracid is not None:
-            change['comments'] = u'From Trac #{tracid} (http://trac.sagemath.org/{tracid})'.format(tracid=unicode(tracid))
+            change['comments'] = \
+                    u'From Trac #{tracid} ({base}/{tracid})'.format(
+                            base=self.env.base_url, tracid=unicode(tracid))
             change['properties']['trac_ticket'] = tracid
 
         for key in change:
@@ -233,7 +235,7 @@ class BuildbotHook(git_merger.GitMerger):
 
         build = self._get_build(req, ticket, True)
 
-        if build is None:
+        if not build:
             return stream
 
         builder, number, rc = build

--- a/sage_trac/common.py
+++ b/sage_trac/common.py
@@ -26,30 +26,30 @@ def hexify(*args):
     return res
 
 class GitBase(Component):
-    master_branch = Option('trac', 'master_branch', 'develop',
+    master_branch = Option('sage_trac', 'master_branch', 'develop',
                            doc='the mainline development branch of the '
                                'repository (by default "develop" for sage ',
                                'for historical reasons)')
 
-    git_dir = PathOption('trac', 'repository_dir', '',
+    git_dir = PathOption('sage_trac', 'repository_dir', '',
                          doc='path to bare git repositories')
 
 
-    cgit_protocol = Option('trac', 'cgit_protocol', 'https',
+    cgit_protocol = Option('sage_trac', 'cgit_protocol', 'https',
                            doc='protocol to use when linking to the cgit '
                                'server (default: https)')
 
-    cgit_host = Option('trac', 'cgit_host', '',
+    cgit_host = Option('sage_trac', 'cgit_host', '',
                        doc='hostname of the cgit server to link to for '
                            'repository viewing')
 
-    cgit_url = Option('trac', 'cgit_url', '',
+    cgit_url = Option('sage_trac', 'cgit_url', '',
                       doc='full URL including protocol, hostname, and '
                           'optional server path of the cgit server to '
                           'link to for repository viewing; this option '
                           'supersedes cgit_protocol and cgit_host')
 
-    cgit_repo = Option('trac', 'cgit_repository', '',
+    cgit_repo = Option('sage_trac', 'cgit_repository', '',
                        doc="name of the project's repository under cgit")
 
     def __init__(self, *args, **kwds):

--- a/sage_trac/common.py
+++ b/sage_trac/common.py
@@ -8,12 +8,6 @@ import os
 import urllib
 import urlparse
 
-MASTER_BRANCH = u'develop'
-MASTER_BRANCHES = {u'develop', u'master'}
-
-WWW_DATA_HOME = '/home/www-data'
-GITOLITE_KEYDIR = os.path.join(WWW_DATA_HOME, 'gitolite', 'keydir')
-GITOLITE_UPDATE = os.path.join(WWW_DATA_HOME, 'bin', 'gitolite-update')
 
 def hexify(*args):
     res = []
@@ -27,6 +21,10 @@ def hexify(*args):
     return res
 
 class GitBase(Component):
+    master_branch = Option('trac', 'master_branch', 'develop',
+                           doc='the mainline development branch of the '
+                               'repository (by default "develop" for sage ',
+                               'for historical reasons)')
 
     git_dir = PathOption('trac', 'repository_dir', '',
                          doc='path to bare git repositories')
@@ -80,7 +78,7 @@ class GitBase(Component):
 
     @property
     def master(self):
-        return self._git.lookup_branch(MASTER_BRANCH).get_object()
+        return self._git.lookup_branch(self.master_branch).get_object()
 
     def generic_lookup(self, ref_or_sha):
         for s in ('refs/heads/', 'refs/tags/'):

--- a/sage_trac/common.py
+++ b/sage_trac/common.py
@@ -4,9 +4,14 @@ from trac.core import Component, TracError
 from trac.config import Option, PathOption
 
 import pygit2
+import re
 import os
 import urllib
 import urlparse
+
+
+# Simple regexp for "Name <email>" signatures
+_signature_re = re.compile(r'\s*(.*\S)\s*<(.+@.+)>\s*$')
 
 
 def hexify(*args):

--- a/sage_trac/sshkeys.py
+++ b/sage_trac/sshkeys.py
@@ -14,7 +14,6 @@ import subprocess
 from threading import Lock
 from fasteners import InterProcessLock as IPLock, locked
 
-from .common import *
 
 class UserDataStore(Component):
     def save_data(self, user, dictionary):

--- a/sage_trac/ticket_log.py
+++ b/sage_trac/ticket_log.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
 
 from trac.core import *
-from trac.config import ListOption
+from trac.config import ListOption, IntOption
 from trac.ticket.api import ITicketManipulator
 
 from .common import GitBase
 
-
-MAX_NEW_COMMITS = 10
 
 class TicketLog(GitBase):
     implements(ITicketManipulator)
@@ -18,6 +16,14 @@ class TicketLog(GitBase):
                                      'branch in [trac]/master_branch by '
                                      'default, as well as "master" if '
                                      '[trac]/master_branch is different')
+
+    max_new_commits = IntOption('sage_trac', 'max_new_commits', 10,
+                                doc='maximum number of commits to display '
+                                    'in the ticket log when new commits are '
+                                    'pushed to an associated branch; in '
+                                    'particular this limit prevents '
+                                    'display of huge lists of commits from '
+                                    'botched merges (default: 10)')
 
     def _valid_commit(self, val):
         if not isinstance(val, basestring):
@@ -88,12 +94,13 @@ class TicketLog(GitBase):
             if old_commit is not None:
                 ignore.add(old_commit)
             try:
-                table = self.log_table(commit, limit=MAX_NEW_COMMITS+1,ignore=ignore)
+                table = self.log_table(commit, limit=self.max_new_commits+1,
+                                       ignore=ignore)
             except (pygit2.GitError, KeyError):
                 return []
-            if len(table) > MAX_NEW_COMMITS:
-                header = u'Last {0} new commits:'.format(MAX_NEW_COMMITS)
-                table = table[:MAX_NEW_COMMITS]
+            if len(table) > self.max_new_commits:
+                header = u'Last {0} new commits:'.format(self.max_new_commits)
+                table = table[:self.max_new_commits]
             else:
                 header = u'New commits:'
             if table:

--- a/sage_trac/ticket_log.py
+++ b/sage_trac/ticket_log.py
@@ -1,16 +1,23 @@
 # -*- coding: utf-8 -*-
 
 from trac.core import *
+from trac.config import ListOption
 from trac.ticket.api import ITicketManipulator
 
-import copy
+from .common import GitBase
 
-from .common import *
 
 MAX_NEW_COMMITS = 10
 
 class TicketLog(GitBase):
     implements(ITicketManipulator)
+
+    ignore_branches = ListOption('sage_trac', 'ignore_branches_in_log', [],
+                                 doc='branches to ignore when displaying the '
+                                     'commit log in tickets; includes the '
+                                     'branch in [trac]/master_branch by '
+                                     'default, as well as "master" if '
+                                     '[trac]/master_branch is different')
 
     def _valid_commit(self, val):
         if not isinstance(val, basestring):
@@ -75,7 +82,9 @@ class TicketLog(GitBase):
                 req.args.get('id') is not None and
                 commit and
                 commit != old_commit):
-            ignore = copy.copy(MASTER_BRANCHES)
+            ignore = set(self.ignore_branches)
+            ignore.add(self.master_branch)
+            ignore.add('master')
             if old_commit is not None:
                 ignore.add(old_commit)
             try:


### PR DESCRIPTION
Some options added by this plugin went into trac.ini under `[sage_trac]`, others under `[trac]`.  The latter should be reserved for Trac itself.  This just makes things more consistent--pretty self-explanatory.
(trac.ini for the Trac environment will of course have to be updated after this).

This depends on #13 going in first.
