### PR TITLE
Add links to github and gitlab branches in ticket

### DIFF
--- a/sage_trac/ticket_box.py
+++ b/sage_trac/ticket_box.py
@@ -135,8 +135,8 @@ class TicketBox(git_merger.GitMerger):
             if url is not None:
                 links.append(tag.a('Commits', href=url))
                 links.append(tag.span(', '))
-            github_url = f"https://github.com/sagemath/sagetrac-mirror/compare/develop...{branch}"
-            gitlab_url = f"https://gitlab.com/sagemath/dev/tracmirror/-/compare/develop...{branch}"
+            github_url = "https://github.com/sagemath/sagetrac-mirror/compare/develop...{}".format(branch)
+            gitlab_url = "https://gitlab.com/sagemath/dev/tracmirror/-/compare/develop...{}".format(branch)
             links.append(tag.a('GitHub', href=github_url))
             links.append(tag.span(', '))
             links.append(tag.a('GitLab', href=gitlab_url))

--- a/sage_trac/ticket_box.py
+++ b/sage_trac/ticket_box.py
@@ -131,7 +131,7 @@ class TicketBox(git_merger.GitMerger):
                     tag.a(class_=class_, href=url))
 
         def commits_link(url):
-            links = tag.span(' ('))
+            links = tag.span(' (')
             if url is not None:
                 links.append(tag.a('Commits', href=url))
                 links.append(tag.span(', '))

--- a/sage_trac/ticket_box.py
+++ b/sage_trac/ticket_box.py
@@ -131,8 +131,17 @@ class TicketBox(git_merger.GitMerger):
                     tag.a(class_=class_, href=url))
 
         def commits_link(url):
-            return FILTER_BRANCH.append(tag.span(' ')).\
-                    append(tag.a('(Commits)', href=url))
+            links = tag.span(' ('))
+            if url is not None:
+                links.append(tag.a('Commits', href=url))
+                links.append(tag.span(', '))
+            github_url = f"https://github.com/sagemath/sagetrac-mirror/compare/develop...{branch}"
+            gitlab_url = f"https://gitlab.com/sagemath/dev/tracmirror/-/compare/develop...{branch}"
+            links.append(tag.a('GitHub', href=github_url))
+            links.append(tag.span(', '))
+            links.append(tag.a('GitLab', href=gitlab_url))
+            links.append(tag.span(')'))
+            return FILTER_BRANCH.append(links)
 
         def error_filters(error):
             return [FILTER_BRANCH.attr("class", "needs_work"),
@@ -178,8 +187,7 @@ class TicketBox(git_merger.GitMerger):
         else:
             git_merger_url = None
 
-        if log_url is not None:
-            filters.append(commits_link(log_url))
+        filters.append(commits_link(log_url))
 
         if ret == git_merger.GIT_UPTODATE:
             filters.append(merge_link(git_merger_url))


### PR DESCRIPTION
Add links to the github and gitlab mirrors in the ticket description, since both have a visual appealing interface and are able to show the content of the branch even with merge conflicts. It should look as follows:
![image](https://user-images.githubusercontent.com/5037600/98540353-19e3ec00-228e-11eb-9cfb-e191361c2b66.png)

(Again with the caveat that I don't know how to test the code...)