### PR TITLE
Add new [sage_trac:status_badges] config

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@
 * Display links to GitHub and GitLab diff viewers for branches, which may be
   nicer to use than the old cgit interface (e.g. allowing code review tools).
 
+* Added ``[sage_trac:status_badges]`` config section for adding additional
+  status badges to ticket pages. [#24]
+
 
 1.2.2 (2018-09-28)
 ==================

--- a/sage_trac/htdocs/sage-ticket.css
+++ b/sage_trac/htdocs/sage-ticket.css
@@ -162,3 +162,16 @@ blockquote.citation {
 #ticket table.properties td[headers="h_branch"] {
  word-wrap: break-word;
 }
+
+#ticket div.badges div {
+  display: flex;
+  align-items: center;
+  margin: 0.5em;
+}
+
+#ticket div.badges h3 {
+    border-bottom: 1px solid #dd9;
+    color: #663;
+    font-size: 100%;
+    font-weight: normal;
+}

--- a/sage_trac/ticket_box.py
+++ b/sage_trac/ticket_box.py
@@ -145,7 +145,7 @@ class TicketBox(git_merger.GitMerger):
             format_vars['ticket_' + k] = v
 
         badge_tags = []
-        for status_badge in reversed(self.status_badges):
+        for status_badge in self.status_badges:
             link_url = status_badge['link_url'].format(**format_vars)
             img_url = status_badge['img_url'].format(**format_vars)
             img_attrs = {
@@ -155,11 +155,10 @@ class TicketBox(git_merger.GitMerger):
             for img_opt in ('width', 'height'):
                 if img_opt in status_badge:
                     img_attrs[img_opt] = status_badge[img_opt]
-            badge_tags.append(tag.div(
-                tag.a(tag.img(**img_attrs), href=link_url),
-                class_='date'))
+            badge_tags.append(tag.a(tag.img(**img_attrs), href=link_url))
 
-        filters.append(FILTER_DATE.after(tag(*badge_tags)))
+        filters.append(FILTER_DATE.after(tag.div(*badge_tags,
+            style='float: right; display: flex; align-items: center;')))
         filters.extend(self._get_branch_filters(req, ticket))
 
         def apply_filters(filters):

--- a/sage_trac/ticket_box.py
+++ b/sage_trac/ticket_box.py
@@ -6,8 +6,9 @@ from genshi.builder import tag
 from genshi.core import TEXT
 from genshi.filters import Transformer
 
+from trac.cache import cached
 from trac.core import implements, TracError
-from trac.config import Option
+from trac.config import Option, ConfigSection
 from trac.web.api import ITemplateStreamFilter
 from trac.web.chrome import add_stylesheet, ITemplateProvider
 
@@ -60,6 +61,30 @@ class TicketBox(git_merger.GitMerger):
             'base URL of the Sage GitLab project from which to show '
             'the ticket build status')
 
+    status_badges_config = ConfigSection('sage_trac:status_badges',
+            """
+            Define custom status badges to display on tickets in this section.
+            Each status badge has a <name> which simply acts as an identity
+            key for the badge, and several options in the format::
+
+                <name>.link_url = <url for anchor tag wrapping the badge>
+                <name>.img_url = <url for the badge image>
+                <name>.order = <relative order of the badge>
+                <name>.height = <height attribute for the image>
+                <name>.width = <width attribute for the image>
+
+            The ``link_url`` and ``img_url`` accept format string templates
+            with the following template variables supported:
+
+            * ``{nonce}``: a random nonce which can be appended to the URL;
+              this can be used to prevent the browser from caching an image
+              for example (this is used e.g. for the patchbot status badges)
+
+            * ``{ticket_<field>}``: for each ticket field there is a variable
+              ``ticket_<field>`` providing its value; e.g. ``ticket_id`` gives
+              the ID of the ticket the badge is displayed on.
+            """)
+
     # Templates on which this filter should be applied
     _templates = set(['ticket_change.html', 'ticket_preview.html',
                       'ticket.html'])
@@ -74,6 +99,23 @@ class TicketBox(git_merger.GitMerger):
                 'in the "Name <email@example.com>" format')
 
         self._release_signature = pygit2.Signature(m.group(1), m.group(2))
+
+    @cached
+    def status_badges(self):
+        config = self.status_badges_config
+        badges = {}
+        int_opts = set(['order', 'height', 'width'])
+        for option, value in config.options():
+            name, opt = option.split('.', 1)
+            badge = badges.setdefault(name, {'name': name})
+            if opt in int_opts:
+                value = config.getint(option)
+            badge[opt] = value
+
+        def sort_key(b):
+            return ('order' not in b, b.get('order'), b['name'])
+
+        return sorted(badges.values(), key=sort_key)
 
     def filter_stream(self, req, method, filename, stream, data):
         """
@@ -93,22 +135,31 @@ class TicketBox(git_merger.GitMerger):
             FILTER_ID.attr('class', 'trac-id-{0}'.format(ticket['status'])),
         ]
 
-        if self.patchbot_url:
-            # Add the patchbot status icons if a patchbot URL was given
-            nonce = hex(random.randint(0, 1 << 60))
-            ticket_url = '{0}/ticket/{1}'.format(
-                    self.patchbot_url.rstrip('/'), ticket.id)
-            base_url = '{0}/base.svg?nonce={1}'.format(ticket_url, nonce)
-            status_url = '{0}/status.svg?nonce={1}'.format(ticket_url, nonce)
-            elem = tag.div(
-                tag.a(
-                    tag.img(src=base_url, border=0, height=32),
-                    tag.img(src=status_url, border=0, height=32),
-                    href=ticket_url),
-                class_='date')
 
-            filters.append(FILTER_DATE.after(elem))
+        format_vars = {
+            'nonce': hex(random.randint(0, 1 << 60)),
+            'ticket_id': ticket.id
+        }
 
+        for k, v in ticket.values.items():
+            format_vars['ticket_' + k] = v
+
+        badge_tags = []
+        for status_badge in reversed(self.status_badges):
+            link_url = status_badge['link_url'].format(**format_vars)
+            img_url = status_badge['img_url'].format(**format_vars)
+            img_attrs = {
+                'src': img_url,
+                'border': 0
+            }
+            for img_opt in ('width', 'height'):
+                if img_opt in status_badge:
+                    img_attrs[img_opt] = status_badge[img_opt]
+            badge_tags.append(tag.div(
+                tag.a(tag.img(**img_attrs), href=link_url),
+                class_='date'))
+
+        filters.append(FILTER_DATE.after(tag(*badge_tags)))
         filters.extend(self._get_branch_filters(req, ticket))
 
         def apply_filters(filters):


### PR DESCRIPTION
Alternate to #22, allowing adding status badges through the config file.

The current implement meets all the needs of the existing patchbot status badges,
as well as the new one proposed in https://github.com/sagemath/sage_trac_plugin/pull/22

We could further extend the feature if more needs arise.

This also obsoletes the patchbot_url option in the [sage_trac] config, since it
was currently only used for generating the status badges.  But I kept it for now.

To give an example of how the config file works, here is the configuration reproducing the existing patchbot status badges, and adding the github one from #22:

```
[sage_trac:status_badges]
patchbot_base.link_url = https://patchbot.sagemath.org/ticket/{ticket_id}
patchbot_base.img_url = https://patchbot.sagemath.org/ticket/{ticket_id}/base.svg?nonce={nonce}
patchbot_base.height = 32
patchbot_base.order = 0
patchbot_status.link_url = https://patchbot.sagemath.org/ticket/{ticket_id}
patchbot_status.img_url = https://patchbot.sagemath.org/ticket/{ticket_id}/status.svg?nonce={nonce}
patchbot_status.height = 32
patchbot_status.order = 1
github_lint.link_url = https://github.com/sagemath/sagetrac-mirror/actions?query=workflow%3ALint+branch%3{ticket_branch}
github_lint.img_url = https://github.com/sagemath/sagetrac-mirror/workflows/Lint/badge.svg?branch={ticket_branch}
github_lint.margin_left = 1em
github_lint.order = 2
```